### PR TITLE
Removed unused `pipes` dependency

### DIFF
--- a/steeloverseer.cabal
+++ b/steeloverseer.cabal
@@ -31,7 +31,6 @@ executable sos
                        process >= 1.1.0.2,
                        text >=0.11.2.3,
                        time >=1.4,
-                       pipes >=3.2,
                        stm >=2.4,
                        regex-tdfa >=1.1.8
 


### PR DESCRIPTION
I was going through `pipes` reverse dependencies in the wake of the `pipes-4.0` transition to fix libraries that used the `3.0` API and noticed that your library does not actually use `pipes` at all.  This pull request removes the dependency.
