### PR TITLE
Simplify some file watching code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/**
 cabal.sandbox.config
 .stack-work/
 .sosrc*
+codex.tags

--- a/package.yaml
+++ b/package.yaml
@@ -34,8 +34,10 @@ dependencies:
   - async      >= 2.0
   - base       >= 4.0 && < 5.0
   - bytestring >= 0.10
+  - fsnotify   >= 0.2
   - mtl        >= 2.2
   - regex-tdfa >= 1.2
+  - resourcet  >= 1.0
   - semigroups >= 0.16
   - stm        >= 2.4
   - streaming  >= 0.1.0 && < 0.1.5
@@ -57,7 +59,6 @@ executables:
     dependencies:
       - steeloverseer
       - directory >= 1.2
-      - fsnotify >= 0.2
       - filepath >= 1.3
       - optparse-applicative >= 0.11
     when:

--- a/src/System/FSNotify/Streaming.hs
+++ b/src/System/FSNotify/Streaming.hs
@@ -1,0 +1,26 @@
+-- | A streaming wrapper around System.FSNotify.
+
+module System.FSNotify.Streaming
+  ( System.FSNotify.Streaming.watchTree
+    -- * Re-exports
+  , Event(..)
+  , WatchManager
+  , defaultConfig
+  ) where
+
+import Control.Concurrent.Chan
+import Control.Monad
+import Control.Monad.Trans.Resource
+import Streaming
+import Streaming.Prelude (yield)
+import System.FSNotify
+
+watchTree
+  :: MonadResource m
+  => WatchConfig -> FilePath -> (Event -> Bool) -> Stream (Of Event) m a
+watchTree config path predicate = do
+  chan         <- liftIO newChan
+  (_, manager) <- allocate (startManagerConf config) stopManager
+  _            <- allocate (watchTreeChan manager path predicate chan) id
+
+  forever (liftIO (readChan chan) >>= yield)

--- a/steeloverseer.cabal
+++ b/steeloverseer.cabal
@@ -35,13 +35,16 @@ library
           Sos.Rule
           Sos.Template
           Sos.Utils
+          System.FSNotify.Streaming
     default-language: Haskell2010
     build-depends:
           async      >= 2.0
         , base       >= 4.0 && < 5.0
         , bytestring >= 0.10
+        , fsnotify   >= 0.2
         , mtl        >= 2.2
         , regex-tdfa >= 1.2
+        , resourcet  >= 1.0
         , semigroups >= 0.16
         , stm        >= 2.4
         , streaming  >= 0.1.0 && < 0.1.5
@@ -62,8 +65,10 @@ executable sos
           async      >= 2.0
         , base       >= 4.0 && < 5.0
         , bytestring >= 0.10
+        , fsnotify   >= 0.2
         , mtl        >= 2.2
         , regex-tdfa >= 1.2
+        , resourcet  >= 1.0
         , semigroups >= 0.16
         , stm        >= 2.4
         , streaming  >= 0.1.0 && < 0.1.5
@@ -71,7 +76,6 @@ executable sos
         , yaml       >= 0.8
         , steeloverseer
         , directory >= 1.2
-        , fsnotify >= 0.2
         , filepath >= 1.3
         , optparse-applicative >= 0.11
     if os(darwin)
@@ -94,8 +98,10 @@ test-suite spec
           async      >= 2.0
         , base       >= 4.0 && < 5.0
         , bytestring >= 0.10
+        , fsnotify   >= 0.2
         , mtl        >= 2.2
         , regex-tdfa >= 1.2
+        , resourcet  >= 1.0
         , semigroups >= 0.16
         , stm        >= 2.4
         , streaming  >= 0.1.0 && < 0.1.5

--- a/test/Sos/TemplateSpec.hs
+++ b/test/Sos/TemplateSpec.hs
@@ -2,7 +2,6 @@ module Sos.TemplateSpec where
 
 import Sos.Template
 
-import Data.Either (isLeft)
 import Test.Hspec
 
 spec :: Spec
@@ -29,3 +28,7 @@ spec = do
     it "errors when there are not enough capture groups" $ do
       instantiateTemplate []    [Left 0] `shouldSatisfy` isLeft
       instantiateTemplate ["a"] [Left 1] `shouldSatisfy` isLeft
+
+isLeft :: Either a b -> Bool
+isLeft (Left _) = True
+isLeft _ = False


### PR DESCRIPTION
I tucked away the watch manager callback into the streaming watch tree (with MonadResource). Slightly simpler code now, and one less indentation!

Also added some random code that fixed 7.6.3 build