### PR TITLE
Bump debounce to 10ms

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -148,8 +148,12 @@ watchTree
 watchTree target = do
   cwd <- liftIO getCurrentDirectory
 
-  let stream :: Stream (Of FSNotify.Event) m a
-      stream = FSNotify.watchTree FSNotify.defaultConfig target (const True)
+  let config :: FSNotify.WatchConfig
+      config = FSNotify.defaultConfig
+        { FSNotify.confDebounce = FSNotify.Debounce 0.1 }
+
+      stream :: Stream (Of FSNotify.Event) m a
+      stream = FSNotify.watchTree config target (const True)
 
   S.for stream (\case
     FSNotify.Added    path _ -> S.yield (FileAdded    (go cwd path))

--- a/src/System/FSNotify/Streaming.hs
+++ b/src/System/FSNotify/Streaming.hs
@@ -5,6 +5,8 @@ module System.FSNotify.Streaming
     -- * Re-exports
   , Event(..)
   , WatchManager
+  , WatchConfig(..)
+  , Debounce(..)
   , defaultConfig
   ) where
 


### PR DESCRIPTION
I noticed lots of duplicate events firing with the default debounce of 1ms. For example, my vim configuration (apparently) touches a file twice, 3ms apart.