### PR TITLE
Better interactive command management

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -53,7 +53,8 @@ library:
     - aeson         >= 0.8
     - ansi-terminal >= 0.6.2
     - containers    >= 0.5
-    - process       >= 1.2
+    - process       >= 1.6.0 && < 1.6.1
+    - unix
 
 executables:
   sos:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,3 @@
 resolver: lts-8.5
+extra-deps:
+  - process-1.6.0.0

--- a/steeloverseer.cabal
+++ b/steeloverseer.cabal
@@ -53,7 +53,8 @@ library
         , aeson         >= 0.8
         , ansi-terminal >= 0.6.2
         , containers    >= 0.5
-        , process       >= 1.2
+        , process       >= 1.6.0 && < 1.6.1
+        , unix
     hs-source-dirs:
           src
     default-extensions: BangPatterns DeriveDataTypeable DeriveFunctor FlexibleContexts InstanceSigs LambdaCase OverloadedStrings RecordWildCards ScopedTypeVariables ViewPatterns


### PR DESCRIPTION
Fixes #20

Now, jobs are run in their own process group, which is sent SIGTERM when the job ends or is terminated. This is a simple effort to kill any non-daemon child processes spawned by the job during its run.

The launched job now needs to be given terminal control so it can read input, which is restored on completion to `sos`. Also, stdin is flushed before running a job, in case the user happened to type some stuff into the terminal on accident (which is never read by `sos`).