### PR TITLE
Add -e for excluding patterns (fixes #25)

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: steeloverseer
-version: '2.0.1.0'
+version: '2.0.2'
 license: BSD3
 license-file: LICENSE
 maintainer: schell.scivally@synapsegrop.com

--- a/src/Sos/Template.hs
+++ b/src/Sos/Template.hs
@@ -41,7 +41,7 @@ type Template = [Either Int ByteString]
 parseTemplate :: MonadThrow m => RawTemplate -> m Template
 parseTemplate raw_template =
   case readP_to_S parser (unpackBS raw_template) of
-    [(template, "")] -> return template
+    [(template, "")] -> pure template
     _ -> throwM (SosCommandParseException raw_template)
  where
   parser :: ReadP Template
@@ -72,7 +72,7 @@ instantiateTemplate vars0 template0 = go 0 vars0 template0
       Left n ->
         let err = "uninstantiated template variable: \\" ++ show n
         in throwM (SosCommandApplyException template0 vars0 err)
-      Right x -> return x
+      Right x -> pure x
   go n (t:ts) template = go (n+1) ts (map f template)
    where
     f :: Either Int ByteString -> Either Int ByteString

--- a/steeloverseer.cabal
+++ b/steeloverseer.cabal
@@ -1,9 +1,9 @@
--- This file has been generated from package.yaml by hpack version 0.17.0.
+-- This file has been generated from package.yaml by hpack version 0.17.1.
 --
 -- see: https://github.com/sol/hpack
 
 name:           steeloverseer
-version:        2.0.1.0
+version:        2.0.2
 cabal-version:  >= 1.10
 build-type:     Simple
 license:        BSD3


### PR DESCRIPTION
Here you go sir, hope it works! Not very well tested, I just played around with it a bit at the command line, so please let me know if you find any bugs.

In summary, added `-e`/`--exclude` flag (`"exclude"` key is optional in the yaml file) that all get lumped together into one big regex that subtracts from every pattern.

So, this:

```
sos -p p1 -e e1 -c c1 -p p2 -e e2 -c2
```

is effectively the same this yaml file:

```
- pattern: p1
  excludes:
    - e1
    - e2
  commands:
    - c1
    - c2
- pattern: p2
  excludes:
    - e1
    - e2
  commands:
    - c1
    - c2
```