### PR TITLE
Parallel commands

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -216,10 +216,10 @@ main' Options{..} = do
 
   race_ (runManaged enqueue_thread) dequeue_thread
 
-eventCommands :: [Rule] -> FileEvent -> IO [ShellCommand]
+eventCommands :: [Rule] -> FileEvent -> IO [[ShellCommand]]
 eventCommands rules event = concat <$> mapM go rules
  where
-  go :: Rule -> IO [ShellCommand]
+  go :: Rule -> IO [[ShellCommand]]
   go rule =
     case (patternMatch, excludeMatch) of
       -- Pattern doesn't match
@@ -227,7 +227,7 @@ eventCommands rules event = concat <$> mapM go rules
       -- Pattern matches, but so does exclude pattern
       (_, True) -> pure []
       -- Pattern matches, and exclude pattern doesn't!
-      (xs, False) -> mapM (instantiateTemplate xs) (ruleTemplates rule)
+      (xs, False) -> mapM (mapM (instantiateTemplate xs)) (ruleTemplates rule)
 
    where
     patternMatch :: [ByteString]

--- a/package.yaml
+++ b/package.yaml
@@ -40,6 +40,7 @@ dependencies:
   - fsnotify >= 0.3
   - managed >= 1.0.1
   - mtl >= 2.2
+  - parallel-io >= 0.3.3
   - regex-tdfa >= 1.2
   - semigroups >= 0.16
   - stm >= 2.4

--- a/package.yaml
+++ b/package.yaml
@@ -40,7 +40,6 @@ dependencies:
   - fsnotify >= 0.3
   - managed >= 1.0.1
   - mtl >= 2.2
-  - parallel-io >= 0.3.3
   - regex-tdfa >= 1.2
   - semigroups >= 0.16
   - stm >= 2.4

--- a/src/Sos/Job.hs
+++ b/src/Sos/Job.hs
@@ -33,8 +33,8 @@ type ShellCommand = String
 -- | A 'Job' is a list of shell commands to run, along with the 'FileEvent' that
 -- triggered the job.
 data Job = Job
-  { jobEvent    :: FileEvent             -- ^ Event that triggered this job.
-  , jobCommands :: NonEmpty ShellCommand -- ^ The list of shell commands to run.
+  { jobEvent    :: FileEvent               -- ^ Event that triggered this job.
+  , jobCommands :: NonEmpty [ShellCommand] -- ^ The list of lists of shell commands to run.
   }
 
 -- | Non-stanard Eq instance: Job equality compares only the shell commands it's

--- a/src/Sos/Template.hs
+++ b/src/Sos/Template.hs
@@ -44,7 +44,7 @@ parseTemplates raw_template =
     _ -> throwM (SosCommandParseException raw_template)
  where
   parser :: ReadP [Template]
-  parser = sepBy parserSingle (packBS <$> string "||")
+  parser = sepBy1 parserSingle (packBS <$> string "||")
 
   parserSingle :: ReadP Template
   parserSingle = some (capturePart <|||> textPart) <* eof

--- a/src/Sos/Template.hs
+++ b/src/Sos/Template.hs
@@ -45,7 +45,7 @@ parseTemplates raw_template =
     _ -> throwM (SosCommandParseException raw_template)
  where
   parser :: ReadP [Template]
-  parser = sepBy1 parserSingle (string "||") <* eof
+  parser = sepBy1 parserSingle (string "|||") <* eof
 
   parserSingle :: ReadP Template
   parserSingle = some (capturePart <|||> textPart)
@@ -56,7 +56,7 @@ parseTemplates raw_template =
       digit :: Char -> Bool
       digit c = c >= '0' && c <= '9'
     textPart :: ReadP ByteString
-    textPart = packBS . concat <$> liftM2 (:) textNoPipePart (Text.ParserCombinators.ReadP.many $ liftM2 (:) (char '|') textNoPipePart)
+    textPart = packBS . concat <$> liftM2 (:) textNoPipePart (Text.ParserCombinators.ReadP.many $ liftM2 (++) (string "|" +++ string "||") textNoPipePart)
      where
       textNoPipePart :: ReadP String
       textNoPipePart = munch1 (\s -> s /= '\\' && s /= '|')

--- a/test/Sos/TemplateSpec.hs
+++ b/test/Sos/TemplateSpec.hs
@@ -9,13 +9,15 @@ spec :: Spec
 spec = do
   describe "parseTemplate" $ do
     it "fails on the empty string" $
-      parseTemplate "" `shouldThrow` anySosException
+      parseTemplates "" `shouldThrow` anySosException
 
     it "parses templates" $ do
-      parseTemplate "hi"      `shouldReturn` [Right "hi"]
-      parseTemplate "foo bar" `shouldReturn` [Right "foo bar"]
-      parseTemplate "\\25"    `shouldReturn` [Left 25]
-      parseTemplate "gcc \\0" `shouldReturn` [Right "gcc ", Left 0]
+      parseTemplates "hi"              `shouldReturn` [[Right "hi"]]
+      parseTemplates "foo bar"         `shouldReturn` [[Right "foo bar"]]
+      parseTemplates "\\25"            `shouldReturn` [[Left 25]]
+      parseTemplates "gcc \\0"         `shouldReturn` [[Right "gcc ", Left 0]]
+      parseTemplates "hi || there"     `shouldReturn` [[Right "hi"], [Right "there"]]
+      parseTemplates "\\25 || gcc \\0" `shouldReturn` [[Left 25], [Right "gcc", Left 0]]
 
   describe "instantiateTemplate" $ do
     it "ignores capture groups in templates with no captures" $ do

--- a/test/Sos/TemplateSpec.hs
+++ b/test/Sos/TemplateSpec.hs
@@ -12,13 +12,14 @@ spec = do
       parseTemplates "" `shouldThrow` anySosException
 
     it "parses templates" $ do
-      parseTemplates "hi"            `shouldReturn` [[Right "hi"]]
-      parseTemplates "foo bar"       `shouldReturn` [[Right "foo bar"]]
-      parseTemplates "\\25"          `shouldReturn` [[Left 25]]
-      parseTemplates "gcc \\0"       `shouldReturn` [[Right "gcc ", Left 0]]
-      parseTemplates "hi||there"     `shouldReturn` [[Right "hi"], [Right "there"]]
-      parseTemplates "\\25||gcc \\0" `shouldReturn` [[Left 25], [Right "gcc ", Left 0]]
-      parseTemplates "hi|there"      `shouldReturn` [[Right "hi|there"]]
+      parseTemplates "hi"             `shouldReturn` [[Right "hi"]]
+      parseTemplates "foo bar"        `shouldReturn` [[Right "foo bar"]]
+      parseTemplates "\\25"           `shouldReturn` [[Left 25]]
+      parseTemplates "gcc \\0"        `shouldReturn` [[Right "gcc ", Left 0]]
+      parseTemplates "hi|||there"     `shouldReturn` [[Right "hi"], [Right "there"]]
+      parseTemplates "\\25|||gcc \\0" `shouldReturn` [[Left 25], [Right "gcc ", Left 0]]
+      parseTemplates "hi|there"       `shouldReturn` [[Right "hi|there"]]
+      parseTemplates "hi||there"      `shouldReturn` [[Right "hi||there"]]
 
   describe "instantiateTemplate" $ do
     it "ignores capture groups in templates with no captures" $ do

--- a/test/Sos/TemplateSpec.hs
+++ b/test/Sos/TemplateSpec.hs
@@ -12,12 +12,13 @@ spec = do
       parseTemplates "" `shouldThrow` anySosException
 
     it "parses templates" $ do
-      parseTemplates "hi"              `shouldReturn` [[Right "hi"]]
-      parseTemplates "foo bar"         `shouldReturn` [[Right "foo bar"]]
-      parseTemplates "\\25"            `shouldReturn` [[Left 25]]
-      parseTemplates "gcc \\0"         `shouldReturn` [[Right "gcc ", Left 0]]
-      parseTemplates "hi || there"     `shouldReturn` [[Right "hi"], [Right "there"]]
-      parseTemplates "\\25 || gcc \\0" `shouldReturn` [[Left 25], [Right "gcc", Left 0]]
+      parseTemplates "hi"            `shouldReturn` [[Right "hi"]]
+      parseTemplates "foo bar"       `shouldReturn` [[Right "foo bar"]]
+      parseTemplates "\\25"          `shouldReturn` [[Left 25]]
+      parseTemplates "gcc \\0"       `shouldReturn` [[Right "gcc ", Left 0]]
+      parseTemplates "hi||there"     `shouldReturn` [[Right "hi"], [Right "there"]]
+      parseTemplates "\\25||gcc \\0" `shouldReturn` [[Left 25], [Right "gcc ", Left 0]]
+      parseTemplates "hi|there"      `shouldReturn` [[Right "hi|there"]]
 
   describe "instantiateTemplate" $ do
     it "ignores capture groups in templates with no captures" $ do


### PR DESCRIPTION
closes #41 

@schell I created a first draft of the functionality, possibly to get a first feedback from you.

I wanted also to ask you the following question: currently, when I try to run commands in parallel, the whole `sos` process goes to background. Is this the default behaviour for [`concurrently`](https://hackage.haskell.org/package/async-2.2.2/docs/Control-Concurrent-Async.html#v:concurrently)? Is there an easy way to keep everything in the foreground?