### PR TITLE
Use aeson-compat to support aeson >= 2.0

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -33,6 +33,7 @@ default-extensions:
   - ViewPatterns
 
 dependencies:
+  - aeson-compat >= 0.3.10
   - async >= 2.0
   - base >= 4.0 && < 5.0
   - bytestring >= 0.10

--- a/src/Sos/Rule.hs
+++ b/src/Sos/Rule.hs
@@ -11,7 +11,8 @@ import Sos.Template
 
 import Control.Applicative
 import Control.Monad.Catch (MonadThrow, throwM)
-import Data.Aeson.Types
+import Data.Aeson.Compat ((.:), FromJSON(..), Parser, Value(..))
+import Data.Aeson.Types (typeMismatch)
 import Data.ByteString (ByteString)
 import Data.ByteString.Internal (c2w)
 import Data.Either


### PR DESCRIPTION
This PR lets my favourite file watching tool build with `aeson-2.0.3.0`.

I have built it with ghc-9.0.2 using both `cabal configure --constraint "aeson>=2.0"` and `cabal configure --constraint "aeson<2.0"`.

Thanks!
